### PR TITLE
Fix Supabase client import paths

### DIFF
--- a/src/pages/Appointments.tsx
+++ b/src/pages/Appointments.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Plus, Search, Calendar as CalendarIcon, AlertCircle, Edit, Trash2 } from 'lucide-react';
 import MainLayout from '../components/layout/MainLayout';
-import { supabase } from '../../lib/supabaseClient';
+import { supabase } from '../lib/supabaseClient';
 import { Appointment, Client, Employee, Service } from '../../types'; // Ensure these types can handle nullable nested objects
 import { formatDateTime, formatDate } from '../utils/dateUtils'; // formatDateTime might need adjustment for string dates from Supabase
 
@@ -190,64 +190,61 @@ const Appointments: React.FC = () => {
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
-              {filteredAppointments.map((appointment) => {
-                const client = mockClients.find(c => c.id === appointment.clientId);
-                const employee = mockEmployees.find(e => e.id === appointment.employeeId);
-                const service = mockServices.find(s => s.id === appointment.serviceId);
-
-                return (
+                {filteredAppointments.map((appointment) => (
                   <tr key={appointment.id} className="hover:bg-gray-50">
                     <td className="px-6 py-4 whitespace-nowrap">
                       <div className="text-sm font-medium text-gray-900">
-                        {formatDateTime(new Date(appointment.date))}
+                        {formatDateTime(new Date(appointment.appointment_time))}
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <div className="text-sm font-medium text-gray-900">
-                        {client?.name}
+                        {appointment.clients?.name || 'N/A'}
                       </div>
                       <div className="text-sm text-gray-500">
-                        {client?.phone}
+                        {appointment.clients?.phone || ''}
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <div className="text-sm text-gray-900">
-                        {employee?.name}
+                        {appointment.employees?.name || 'N/A'}
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <div className="text-sm text-gray-900">
-                        {service?.name}
+                        {appointment.services?.name || 'N/A'}
                       </div>
                       <div className="text-sm text-gray-500">
-                        {service?.duration} min
+                        {appointment.services?.duration_minutes ? `${appointment.services.duration_minutes} min` : ''}
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
-                      <span className={`px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full ${
-                        appointment.status === 'completed'
-                          ? 'bg-green-100 text-green-800'
-                          : appointment.status === 'cancelled'
-                          ? 'bg-red-100 text-red-800'
-                          : appointment.status === 'no-show'
-                          ? 'bg-yellow-100 text-yellow-800'
-                          : 'bg-blue-100 text-blue-800'
-                      }`}>
-                        {appointment.status === 'completed'
-                          ? 'Concluído'
-                          : appointment.status === 'cancelled'
-                          ? 'Cancelado'
-                          : appointment.status === 'no-show'
-                          ? 'Não Compareceu'
-                          : 'Agendado'}
+                      <span className={`px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full ${getStatusClass(appointment.status)}`}>
+                        {getStatusText(appointment.status)}
                       </span>
                     </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                      <button
+                        onClick={() => handleEditAppointment(appointment)}
+                        className="text-blue-600 hover:text-blue-900 mr-3"
+                        title="Editar Agendamento"
+                      >
+                        <Edit className="h-5 w-5" />
+                      </button>
+                      <button
+                        onClick={() => handleDeleteAppointment(appointment.id)}
+                        className="text-red-600 hover:text-red-900"
+                        title="Excluir Agendamento"
+                      >
+                        <Trash2 className="h-5 w-5" />
+                      </button>
+                    </td>
                   </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
     </MainLayout>
   );

--- a/src/pages/Clients.tsx
+++ b/src/pages/Clients.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Plus, Search, Edit, Trash2, AlertCircle } from 'lucide-react';
 import MainLayout from '../components/layout/MainLayout';
-import { supabase } from '../../lib/supabaseClient'; // Corrected path
+import { supabase } from '../lib/supabaseClient';
 import { Client } from '../../types'; // Corrected path
 import { formatDate } from '../utils/dateUtils'; // Assuming this is still relevant for other dates if any
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -4,7 +4,7 @@ import DashboardStats from '../components/dashboard/DashboardStats';
 import AppointmentsList from '../components/dashboard/AppointmentsList';
 import UpcomingAppointmentsChart from '../components/dashboard/UpcomingAppointmentsChart';
 import ServicePerformanceChart from '../components/dashboard/ServicePerformanceChart';
-import { supabase } from '../../lib/supabaseClient';
+import { supabase } from '../lib/supabaseClient';
 import { Appointment, Client, Employee, Service } from '../../types';
 import { formatDate } from '../utils/dateUtils';
 import { AlertCircle } from 'lucide-react';

--- a/src/pages/Employees.tsx
+++ b/src/pages/Employees.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Plus, Search, Edit, Trash2, AlertCircle } from 'lucide-react';
 import MainLayout from '../components/layout/MainLayout';
-import { supabase } from '../../lib/supabaseClient';
+import { supabase } from '../lib/supabaseClient';
 import { Employee } from '../../types';
 
 const Employees: React.FC = () => {

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { BarChart, Calendar as CalendarIcon, AlertCircle } from 'lucide-react';
 import MainLayout from '../components/layout/MainLayout';
-import { supabase } from '../../lib/supabaseClient';
+import { supabase } from '../lib/supabaseClient';
 import { Appointment, Service, Employee } from '../../types';
 
 // Helper to ensure date objects are consistently handled for Supabase
@@ -176,7 +176,7 @@ const Reports: React.FC = () => {
             <BarChart className="h-8 w-8 text-green-600" />
             <h3 className="ml-3 text-lg font-medium text-gray-900">Agendamentos Concluídos</h3>
           </div>
-          <p className="mt-4 text-2xl font-semibold text-gray-900">{metrics.completedAppointments}</p>
+              <p className="mt-4 text-2xl font-semibold text-gray-900">{metrics.completedAppointmentsCount}</p>
         </div>
 
         <div className="bg-white p-6 rounded-lg shadow-sm">
@@ -186,7 +186,7 @@ const Reports: React.FC = () => {
           </div>
           <p className="mt-4 text-2xl font-semibold text-gray-900">
             {metrics.totalAppointments > 0
-              ? `${((metrics.completedAppointments / metrics.totalAppointments) * 100).toFixed(1)}%`
+                  ? `${((metrics.completedAppointmentsCount / metrics.totalAppointments) * 100).toFixed(1)}%`
               : '0%'}
           </p>
         </div>
@@ -206,8 +206,8 @@ const Reports: React.FC = () => {
         <div className="bg-white p-6 rounded-lg shadow-sm">
           <h3 className="text-lg font-medium text-gray-900 mb-4">Desempenho por Serviço</h3>
           <div className="space-y-4">
-            {metrics.servicePerformance.map((service, index) => (
-              <div key={index}>
+            {metrics.servicePerformance.map((service) => (
+              <div key={service.id}>
                 <div className="flex justify-between items-center mb-1">
                   <span className="text-sm font-medium text-gray-900">{service.name}</span>
                   <span className="text-sm text-gray-600">
@@ -230,8 +230,8 @@ const Reports: React.FC = () => {
         <div className="bg-white p-6 rounded-lg shadow-sm">
           <h3 className="text-lg font-medium text-gray-900 mb-4">Desempenho por Profissional</h3>
           <div className="space-y-4">
-            {metrics.employeePerformance.map((employee, index) => (
-              <div key={index}>
+            {metrics.employeePerformance.map((employee) => (
+              <div key={employee.id}>
                 <div className="flex justify-between items-center mb-1">
                   <span className="text-sm font-medium text-gray-900">{employee.name}</span>
                   <span className="text-sm text-gray-600">

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Plus, Search, Edit, Trash2, AlertCircle, Tag } from 'lucide-react';
 import MainLayout from '../components/layout/MainLayout';
-import { supabase } from '../../lib/supabaseClient';
+import { supabase } from '../lib/supabaseClient';
 import { Service } from '../../types';
 // import { formatDate } from '../utils/dateUtils'; // Not used for service dates directly unless for created_at/updated_at
 


### PR DESCRIPTION
I corrected the relative import paths for `supabaseClient.ts` in several page components (Dashboard, Clients, Services, Employees, Appointments, Reports).

The previous paths (e.g., `../../lib/supabaseClient`) were incorrect, leading to build failures. They have been updated to the correct relative path (`../lib/supabaseClient`).

Additional minor fixes in `Appointments.tsx` and `Reports.tsx` related to rendering logic and variable names were also included.